### PR TITLE
Add declarative PC setup for migration

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -1,6 +1,8 @@
 {{- $name := promptStringOnce . "name" "Git user name" -}}
 {{- $email := promptStringOnce . "email" "Git email address" -}}
-{{- $signingkey := promptStringOnce . "signingkey" "SSH public key for commit signing (leave empty to skip)" -}}
+
+{{- /* Auto-fetch SSH public key from 1Password if signed in, otherwise empty */ -}}
+{{- $signingkey := output "sh" "-c" "op item get 'Github SSHキー' --account my.1password.com --fields public_key 2>/dev/null || true" | trim -}}
 
 data:
   name: {{ $name | quote }}

--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -1,8 +1,25 @@
-{{- $name := promptStringOnce . "name" "Git user name" -}}
-{{- $email := promptStringOnce . "email" "Git email address" -}}
+{{- /* ─── Git config profile ─── */ -}}
+{{- $profile := promptChoiceOnce . "profile" "Git config profile" (list "personal (tktcorporation <tktcorporation.go@gmail.com>)" "manual") -}}
 
-{{- /* Auto-fetch SSH public key from 1Password if signed in, otherwise empty */ -}}
-{{- $signingkey := output "sh" "-c" "op item get 'Github SSHキー' --account my.1password.com --fields public_key 2>/dev/null || true" | trim -}}
+{{- $name := "" -}}
+{{- $email := "" -}}
+{{- if hasPrefix "personal" $profile -}}
+{{-   $name = "tktcorporation" -}}
+{{-   $email = "tktcorporation.go@gmail.com" -}}
+{{- else -}}
+{{-   $name = promptStringOnce . "name" "Git user name" -}}
+{{-   $email = promptStringOnce . "email" "Git email address" -}}
+{{- end -}}
+
+{{- /* ─── SSH signing key from 1Password ─── */ -}}
+{{- $signingkey := "" -}}
+{{- $detectedKey := output "sh" "-c" "op item get 'Github SSHキー' --account my.1password.com --fields public_key 2>/dev/null || true" | trim -}}
+{{- if $detectedKey -}}
+{{-   $useKey := promptBoolOnce . "useDetectedKey" (printf "Use this SSH key for commit signing?\n  %s" $detectedKey) -}}
+{{-   if $useKey -}}
+{{-     $signingkey = $detectedKey -}}
+{{-   end -}}
+{{- end -}}
 
 data:
   name: {{ $name | quote }}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -5,3 +5,4 @@ LICENSE.txt
 .github
 .gitignore
 CLAUDE.md
+.claude

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,4 @@
-# Core tools
+# ─── Core CLI Tools ───
 brew "chezmoi"
 brew "gh"
 brew "ghq"
@@ -10,14 +10,63 @@ brew "ripgrep"
 brew "fd"
 brew "bat"
 brew "eza"
+brew "mas"
 
-# 1Password CLI
+# ─── Runtime Manager ───
+brew "mise"
+
+# ─── Development Tools ───
+brew "cocoapods"
+brew "fastlane"
+
+# ─── Media & Utilities ───
+brew "ffmpeg"
+brew "exiftool"
+
+# ─── Security & Networking ───
 brew "1password-cli"
+brew "cloudflared"
 
-# macOS apps
 if OS.mac?
+  # ─── Essentials ───
   cask "1password"
+  cask "raycast"
+
+  # ─── Terminals & Editors ───
   cask "ghostty"
   cask "warp"
   cask "visual-studio-code"
+  cask "cursor"
+
+  # ─── Browsers ───
+  cask "arc"
+  cask "google-chrome"
+
+  # ─── Communication ───
+  cask "slack"
+  cask "discord"
+
+  # ─── Productivity ───
+  cask "notion"
+  cask "notion-calendar"
+
+  # ─── Dev Infrastructure ───
+  cask "orbstack"
+  cask "cloudflare-warp"
+  cask "tailscale"
+
+  # ─── Creative / Media ───
+  cask "screen-studio"
+  cask "cleanshot"
+  cask "inkscape"
+
+  # ─── Other ───
+  cask "chatgpt"
+  cask "thunderbird"
+  cask "steam"
+
+  # ─── Mac App Store ───
+  # mas install requires App Store sign-in
+  mas "LINE", id: 539883307
+  mas "Xcode", id: 497799835
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-[chezmoi](https://www.chezmoi.io/) + [Brewfile](https://github.com/Homebrew/homebrew-bundle) + [1Password CLI](https://developer.1password.com/docs/cli/) で管理するシンプルな dotfiles.
+[chezmoi](https://www.chezmoi.io/) + [Brewfile](https://github.com/Homebrew/homebrew-bundle) + [1Password CLI](https://developer.1password.com/docs/cli/) + [mise](https://mise.jdx.dev/) で管理する dotfiles.
 
 ## Setup
 
@@ -12,12 +12,16 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply tktcorporation
 
 1. **chezmoi** インストール
 2. **Homebrew** インストール (未導入の場合)
-3. **Brewfile** の全パッケージインストール (gh, ghq, fzf, direnv, zoxide, 1password-cli, ...)
+3. **Brewfile** の全パッケージインストール (CLI ツール, cask アプリ, Mac App Store)
 4. **~/.gitconfig** 展開 (name/email/signing key をプロンプトで設定)
 5. **~/.gitignore_global** 展開
-6. **~/.zprofile** 展開 (Homebrew PATH)
-7. **~/.zshrc** 展開 (zoxide, direnv, fzf, ghq/fzf aliases)
-8. **~/.ssh/config** 展開 (1Password SSH agent)
+6. **~/.zprofile** 展開 (Homebrew PATH + OrbStack)
+7. **~/.zshrc** 展開 (mise, zoxide, direnv, fzf, aliases)
+8. **~/.ssh/config** 展開 (1Password SSH agent + OrbStack)
+9. **~/.config/mise/config.toml** 展開 (node, python, bun, pnpm 等)
+10. **~/.config/ghostty/config** 展開
+11. **macOS defaults** 適用 (Dock, Finder, キーボード設定)
+12. **mise install** で各ランタイムインストール
 
 ### 更新
 
@@ -32,15 +36,24 @@ chezmoi update
 Brewfile                                     # brew bundle で管理するパッケージ
 dot_gitconfig.tmpl                           # ~/.gitconfig (aliases + 1Password signing)
 dot_gitignore_global                         # ~/.gitignore_global
-dot_zprofile.tmpl                            # ~/.zprofile (Homebrew PATH)
-dot_zshrc                                    # ~/.zshrc (tool init + aliases)
-private_dot_ssh/private_config.tmpl          # ~/.ssh/config (1Password SSH agent)
+dot_zprofile.tmpl                            # ~/.zprofile (Homebrew PATH + OrbStack)
+dot_zshrc                                    # ~/.zshrc (mise, tool init, aliases)
+private_dot_ssh/private_config.tmpl          # ~/.ssh/config (1Password SSH agent + OrbStack)
+dot_config/mise/config.toml                  # ~/.config/mise/config.toml (ランタイム管理)
+dot_config/ghostty/config                    # ~/.config/ghostty/config
 run_onchange_before_install-packages.sh.tmpl # Brewfile 変更時に自動で brew bundle
+run_once_after_macos-defaults.sh.tmpl        # macOS 初回セットアップ時のシステム設定
+run_onchange_after_setup-tools.sh.tmpl       # mise config 変更時にランタイムインストール
 ```
 
 ## パッケージ管理
 
 `Brewfile` を編集して `chezmoi apply` すると自動で `brew bundle` が走ります.
+
+## ランタイム管理
+
+[mise](https://mise.jdx.dev/) で node, python, bun, pnpm, uv 等を一元管理しています.
+`dot_config/mise/config.toml` を編集して `chezmoi apply` すると自動で `mise install` が走ります.
 
 ## 1Password 連携
 
@@ -49,7 +62,8 @@ run_onchange_before_install-packages.sh.tmpl # Brewfile 変更時に自動で br
 
 ## ローカル上書き
 
-`~/.gitconfig.local` でマシン固有の設定を追加できます.
+- `~/.gitconfig.local` でマシン固有の Git 設定を追加できます
+- `~/.zshrc.local` でマシン固有のシェル設定を追加できます
 
 ## License
 

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,0 +1,2 @@
+font-size = 14
+theme = auto

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -1,0 +1,9 @@
+[tools]
+node = "22"
+"npm:@anthropic-ai/claude-code" = "latest"
+"npm:@devcontainers/cli" = "0.81.1"
+"npm:@antfu/ni" = "27.0.1"
+bun = "1.3.5"
+pnpm = "10.25.0"
+python = "3.14.2"
+uv = "0.9.6"

--- a/dot_zprofile.tmpl
+++ b/dot_zprofile.tmpl
@@ -8,3 +8,6 @@ eval "$(/usr/local/bin/brew shellenv)"
 {{- else }}
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 {{- end }}
+
+# OrbStack shell integration (if installed)
+source ~/.orbstack/shell/init.zsh 2>/dev/null || :

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,4 +1,4 @@
-# History
+# ─── History ───
 HISTSIZE=10000
 SAVEHIST=10000
 HISTFILE=~/.zsh_history
@@ -6,21 +6,35 @@ setopt share_history
 setopt hist_ignore_all_dups
 setopt hist_ignore_space
 
-# Completion
+# ─── Completion ───
 autoload -Uz compinit && compinit
 
-# Tools
+# ─── Runtime Manager ───
+eval "$(mise activate zsh)"
+
+# ─── Tools ───
 eval "$(zoxide init zsh)"
 eval "$(direnv hook zsh)"
 source <(fzf --zsh)
 
-# Aliases
+# ─── Aliases ───
 alias g="git"
 alias ll="eza -l"
 alias la="eza -la"
 alias cat="bat --plain"
-alias gcd='cd $(ghq root)/$(ghq list | fzf)'
+
+# ─── Functions ───
+function ghqcd() {
+  local selected_repo=$(ghq list | fzf --query="$1" --preview "ls -la $(ghq root)/{}")
+  if [[ -n "$selected_repo" ]]; then
+    cd "$(ghq root)/$selected_repo"
+  fi
+}
+alias gcd="ghqcd"
 alias ghr='gh repo view --web'
 
-# Editor
-export EDITOR="code"
+# ─── Editor ───
+export EDITOR="code --wait"
+
+# ─── Machine-local config ───
+[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local

--- a/private_dot_ssh/private_config.tmpl
+++ b/private_dot_ssh/private_config.tmpl
@@ -1,4 +1,8 @@
 {{- if eq .chezmoi.os "darwin" }}
+{{ if stat (joinPath .chezmoi.homeDir ".orbstack/ssh/config") -}}
+Include ~/.orbstack/ssh/config
+
+{{ end -}}
 Host *
     IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 {{- else }}

--- a/run_once_after_macos-defaults.sh.tmpl
+++ b/run_once_after_macos-defaults.sh.tmpl
@@ -1,0 +1,21 @@
+#!/bin/bash
+{{ if eq .chezmoi.os "darwin" -}}
+set -euo pipefail
+
+# ─── Dock ───
+defaults write com.apple.dock autohide -bool true
+defaults write com.apple.dock mru-spaces -bool false
+defaults write com.apple.dock show-recents -bool false
+
+# ─── Finder ───
+defaults write com.apple.finder AppleShowAllExtensions -bool true
+defaults write com.apple.finder FXPreferredViewStyle -string "clmv"
+defaults write com.apple.finder ShowPathbar -bool true
+defaults write com.apple.finder ShowStatusBar -bool true
+
+# ─── Keyboard ───
+defaults write NSGlobalDomain InitialKeyRepeat -int 25
+defaults write NSGlobalDomain KeyRepeat -int 2
+
+killall Dock Finder 2>/dev/null || true
+{{ end -}}

--- a/run_onchange_after_setup-tools.sh.tmpl
+++ b/run_onchange_after_setup-tools.sh.tmpl
@@ -1,0 +1,8 @@
+#!/bin/bash
+# mise config hash: {{ include "dot_config/mise/config.toml" | sha256sum }}
+set -euo pipefail
+
+if command -v mise &>/dev/null; then
+  echo "Installing mise-managed tools..."
+  mise install --yes
+fi


### PR DESCRIPTION
## Summary
- Brewfile を大幅拡張 (16 formulae + 17 casks + 2 mas apps) — 実際に使っているアプリを網羅
- ランタイム管理を mise に統一 (volta 廃止) — node, python, bun, pnpm, uv, claude-code を一元管理
- macOS システム設定を `run_once_` スクリプトで宣言的に管理 (Dock, Finder, キーボード)
- OrbStack の shell/SSH integration を条件付きで追加
- `~/.zshrc.local` によるマシン固有設定のサポートを追加
- Ghostty の最小限の設定ファイルを追加

## 新しいPCでのセットアップ

```bash
sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply tktcorporation
```

## Test plan
- [ ] `chezmoi diff` で差分を確認
- [ ] `chezmoi apply --dry-run -v` でドライラン
- [ ] 新しいPCで上記ワンライナーを実行してセットアップが完了することを確認
- [ ] `chezmoi apply` を2回実行して冪等性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)