### PR TITLE
Add xcode-select prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 ## Setup
 
 ```bash
+# Xcode Command Line Tools (新しい Mac では必須)
+xcode-select --install
+
+# dotfiles セットアップ
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply tktcorporation
 ```
 


### PR DESCRIPTION
## Summary
- 新しい Mac では Xcode Command Line Tools がないと `git` が使えず `chezmoi init` が失敗するため、`xcode-select --install` を README に追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)