### PR TITLE
fix: Xcode CLT を softwareupdate でヘッドレスインストール

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,21 +10,47 @@ if ! xcode-select -p &>/dev/null; then
     # softwareupdate を使い GUI ダイアログなしでインストールする。
     # xcode-select --install は GUI 操作が必要なため、
     # curl | bash のようなヘッドレス実行では完了できない。
+    # パターンは Homebrew の install.sh を参考にしている。
     touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
-    XCODE_PKG=$(softwareupdate -l 2>/dev/null \
-        | grep -o 'Command Line Tools.*' \
-        | head -n 1)
 
-    if [ -z "$XCODE_PKG" ]; then
+    # softwareupdate の出力形式は macOS バージョンにより異なる:
+    #   旧: "* Command Line Tools (macOS Mojave version 10.14) for Xcode-10.2"
+    #   新: "* Label: Command Line Tools for Xcode-14.0"
+    # sort -V | tail -n1 で最新安定版を選択（head -n1 だとベータを拾う場合がある）。
+    CLT_LABEL=$(softwareupdate -l 2>/dev/null \
+        | grep -B 1 -E 'Command Line Tools' \
+        | awk -F'*' '/^ *\*/ {print $2}' \
+        | sed -e 's/^ *Label: //' -e 's/^ *//' \
+        | sort -V \
+        | tail -n1)
+
+    if [ -n "$CLT_LABEL" ]; then
+        echo "    Installing: $CLT_LABEL"
+        softwareupdate -i "$CLT_LABEL"
+    else
+        # softwareupdate でパッケージが見つからない場合、
+        # TTY 環境なら xcode-select --install にフォールバックする。
         rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
-        echo "ERROR: Xcode Command Line Tools package not found via softwareupdate." >&2
-        echo "       Please install manually: xcode-select --install" >&2
-        exit 1
+        if [ -t 0 ]; then
+            echo "    softwareupdate にパッケージが見つかりません。GUI インストーラを起動します..."
+            xcode-select --install
+            echo "    GUI ダイアログに従ってインストールしてください。完了を待機中..."
+            until xcode-select -p &>/dev/null; do
+                sleep 5
+            done
+        else
+            echo "ERROR: Xcode Command Line Tools package not found via softwareupdate." >&2
+            echo "       Please install manually: xcode-select --install" >&2
+            exit 1
+        fi
     fi
 
-    echo "    Installing: $XCODE_PKG"
-    softwareupdate -i "$XCODE_PKG"
     rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+
+    # インストール先のパスを明示的に設定する
+    if [ -d /Library/Developer/CommandLineTools ]; then
+        sudo xcode-select --switch /Library/Developer/CommandLineTools
+    fi
 
     if xcode-select -p &>/dev/null; then
         echo "==> Xcode Command Line Tools installed."

--- a/setup.sh
+++ b/setup.sh
@@ -6,13 +6,33 @@ echo "==> dotfiles setup"
 # ── Xcode Command Line Tools ────────────────────────────────────
 if ! xcode-select -p &>/dev/null; then
     echo "==> Installing Xcode Command Line Tools..."
-    xcode-select --install
 
-    echo "    Waiting for installation to complete (follow the GUI dialog)..."
-    until xcode-select -p &>/dev/null; do
-        sleep 5
-    done
-    echo "==> Xcode Command Line Tools installed."
+    # softwareupdate を使い GUI ダイアログなしでインストールする。
+    # xcode-select --install は GUI 操作が必要なため、
+    # curl | bash のようなヘッドレス実行では完了できない。
+    touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+    XCODE_PKG=$(softwareupdate -l 2>/dev/null \
+        | grep -o 'Command Line Tools.*' \
+        | head -n 1)
+
+    if [ -z "$XCODE_PKG" ]; then
+        rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+        echo "ERROR: Xcode Command Line Tools package not found via softwareupdate." >&2
+        echo "       Please install manually: xcode-select --install" >&2
+        exit 1
+    fi
+
+    echo "    Installing: $XCODE_PKG"
+    softwareupdate -i "$XCODE_PKG"
+    rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+
+    if xcode-select -p &>/dev/null; then
+        echo "==> Xcode Command Line Tools installed."
+    else
+        echo "ERROR: Installation finished but xcode-select still not available." >&2
+        echo "       Please install manually: xcode-select --install" >&2
+        exit 1
+    fi
 else
     echo "==> Xcode Command Line Tools already installed."
 fi


### PR DESCRIPTION
## Summary

- `xcode-select --install` は GUI ダイアログが必要なため、`bash <(curl ...)` のヘッドレス実行では永遠に待機してしまう問題を修正
- `softwareupdate` コマンドを使った GUI 不要のインストール方式に変更（Homebrew install.sh と同じアプローチ）
- `softwareupdate` でパッケージが見つからない場合、TTY 環境なら `xcode-select --install` にフォールバック

## 変更内容

| 項目 | 旧 | 新 |
|------|-----|-----|
| インストール方法 | `xcode-select --install` + 無限ループ待機 | `softwareupdate -i` でヘッドレスインストール |
| ラベル抽出 | なし | Homebrew 準拠の `grep -B1` + `awk` + `sed` + `sort -V` パターン |
| バージョン選択 | なし | `sort -V \| tail -n1` で最新安定版（ベータ回避） |
| フォールバック | なし | TTY 環境では `xcode-select --install` に自動切替 |
| パス設定 | なし | `xcode-select --switch` で明示的に設定 |

## 参考

- [Homebrew install.sh](https://github.com/Homebrew/install/blob/HEAD/install.sh) - 最も実績のある softwareupdate パターン
- [timsutton/osx-vm-templates](https://github.com/timsutton/osx-vm-templates/blob/master/scripts/xcode-cli-tools.sh) - VM 向けヘッドレスインストール
- [mokacoding - How to install Xcode CLI Tools without GUI](https://mokacoding.com/blog/how-to-install-xcode-cli-tools-without-gui/)

## Test plan

- [ ] macOS で `xcode-select` 未インストール状態から `bash <(curl ...)` でセットアップが完了することを確認
- [ ] 既にインストール済みの環境で "already installed" と表示されスキップされることを確認

https://claude.ai/code/session_012XBv6PSCe5UugfyAxAGJQK