### PR TITLE
Remove --no-lock flag from brew bundle command

### DIFF
--- a/run_onchange_before_install-packages.sh.tmpl
+++ b/run_onchange_before_install-packages.sh.tmpl
@@ -19,4 +19,4 @@ if ! command -v brew &>/dev/null; then
 fi
 
 echo "Running brew bundle..."
-brew bundle --file={{ joinPath .chezmoi.sourceDir "Brewfile" | quote }} --no-lock
+brew bundle --file={{ joinPath .chezmoi.sourceDir "Brewfile" | quote }}


### PR DESCRIPTION
## Summary
Removed the `--no-lock` flag from the `brew bundle` command in the pre-install setup script, allowing Homebrew to generate and maintain a lock file during package installation.

## Changes
- Removed `--no-lock` flag from the `brew bundle` command
- This allows Homebrew to create and update a `Brewfile.lock.json` file, which locks dependency versions for reproducible installations

## Details
Previously, the script explicitly disabled lock file generation with the `--no-lock` flag. By removing this flag, the default behavior of `brew bundle` is restored, which will now generate a lock file to ensure consistent package versions across different installations and machines.

https://claude.ai/code/session_018kmfqM9dN6QTN4hC1PrF6U