### PR TITLE
Add aqua-voice, typeless, claude, notion-mail to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -49,6 +49,7 @@ if OS.mac?
   # ─── Productivity ───
   cask "notion"
   cask "notion-calendar"
+  cask "notion-mail"
 
   # ─── Dev Infrastructure ───
   cask "orbstack"
@@ -60,8 +61,15 @@ if OS.mac?
   cask "cleanshot"
   cask "inkscape"
 
-  # ─── Other ───
+  # ─── AI ───
   cask "chatgpt"
+  cask "claude"
+
+  # ─── Input ───
+  cask "aqua-voice"
+  cask "typeless"
+
+  # ─── Other ───
   cask "thunderbird"
   cask "steam"
 


### PR DESCRIPTION
## Summary
- `claude` — AI assistant
- `notion-mail` — Notion suite 揃える
- `aqua-voice` — 音声入力
- `typeless` — 入力支援

arc は既に Brewfile に含まれていたため追加不要でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)