### PR TITLE
Add sudo keepalive and reorganize 1password installation

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -24,12 +24,12 @@ brew "ffmpeg"
 brew "exiftool"
 
 # ─── Security & Networking ───
-brew "1password-cli"
 brew "cloudflared"
 
 if OS.mac?
   # ─── Essentials ───
   cask "1password"
+  cask "1password-cli"
   cask "raycast"
 
   # ─── Terminals & Editors ───

--- a/run_onchange_before_install-packages.sh.tmpl
+++ b/run_onchange_before_install-packages.sh.tmpl
@@ -8,12 +8,14 @@ set -euo pipefail
 # パスワードを求められるのを防ぐため、最初に1回だけ認証し
 # バックグラウンドでタイムスタンプを更新し続ける。
 # パターンは Homebrew install.sh / mathiasbynens/dotfiles を参考。
-echo "==> Administrator password required for package installation."
-sudo -v
-while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
-SUDO_KEEPALIVE_PID=$!
-# スクリプト終了時にバックグラウンドプロセスを確実に停止する
-trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT
+# sudo が存在しない環境（Linuxbrew を非 root で使う場合等）ではスキップする。
+if command -v sudo &>/dev/null; then
+    echo "==> Administrator password required for package installation."
+    sudo -v
+    while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
+    SUDO_KEEPALIVE_PID=$!
+    trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT
+fi
 
 # Install Homebrew if not present
 if ! command -v brew &>/dev/null; then

--- a/run_onchange_before_install-packages.sh.tmpl
+++ b/run_onchange_before_install-packages.sh.tmpl
@@ -8,10 +8,9 @@ set -euo pipefail
 # パスワードを求められるのを防ぐため、最初に1回だけ認証し
 # バックグラウンドでタイムスタンプを更新し続ける。
 # パターンは Homebrew install.sh / mathiasbynens/dotfiles を参考。
-# sudo が存在しない環境（Linuxbrew を非 root で使う場合等）ではスキップする。
-if command -v sudo &>/dev/null; then
-    echo "==> Administrator password required for package installation."
-    sudo -v
+# sudo が存在しない環境や、sudoers に入っていない環境
+# （Linuxbrew 非 root、CI コンテナ等）ではスキップする。
+if command -v sudo &>/dev/null && sudo -v 2>/dev/null; then
     while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
     SUDO_KEEPALIVE_PID=$!
     trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT

--- a/run_onchange_before_install-packages.sh.tmpl
+++ b/run_onchange_before_install-packages.sh.tmpl
@@ -3,6 +3,18 @@ set -euo pipefail
 
 # Brewfile hash: {{ include "Brewfile" | sha256sum }}
 
+# ── sudo keepalive ──────────────────────────────────────────────
+# Homebrew のインストールや cask のインストール時に何度も
+# パスワードを求められるのを防ぐため、最初に1回だけ認証し
+# バックグラウンドでタイムスタンプを更新し続ける。
+# パターンは Homebrew install.sh / mathiasbynens/dotfiles を参考。
+echo "==> Administrator password required for package installation."
+sudo -v
+while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
+SUDO_KEEPALIVE_PID=$!
+# スクリプト終了時にバックグラウンドプロセスを確実に停止する
+trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT
+
 # Install Homebrew if not present
 if ! command -v brew &>/dev/null; then
     echo "Installing Homebrew..."

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,15 @@ set -euo pipefail
 
 echo "==> dotfiles setup"
 
+# ── sudo keepalive ──────────────────────────────────────────────
+# セットアップ中に何度もパスワードを求められるのを防ぐため、
+# 最初に1回だけ認証しバックグラウンドでタイムスタンプを更新し続ける。
+echo "==> Administrator password required for setup."
+sudo -v
+while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
+SUDO_KEEPALIVE_PID=$!
+trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT
+
 # ── Xcode Command Line Tools ────────────────────────────────────
 if ! xcode-select -p &>/dev/null; then
     echo "==> Installing Xcode Command Line Tools..."

--- a/setup.sh
+++ b/setup.sh
@@ -6,10 +6,8 @@ echo "==> dotfiles setup"
 # ── sudo keepalive ──────────────────────────────────────────────
 # セットアップ中に何度もパスワードを求められるのを防ぐため、
 # 最初に1回だけ認証しバックグラウンドでタイムスタンプを更新し続ける。
-# sudo が存在しない環境ではスキップする。
-if command -v sudo &>/dev/null; then
-    echo "==> Administrator password required for setup."
-    sudo -v
+# sudo が存在しない環境や、sudoers に入っていない環境ではスキップする。
+if command -v sudo &>/dev/null && sudo -v 2>/dev/null; then
     while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
     SUDO_KEEPALIVE_PID=$!
     trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT

--- a/setup.sh
+++ b/setup.sh
@@ -6,11 +6,14 @@ echo "==> dotfiles setup"
 # ── sudo keepalive ──────────────────────────────────────────────
 # セットアップ中に何度もパスワードを求められるのを防ぐため、
 # 最初に1回だけ認証しバックグラウンドでタイムスタンプを更新し続ける。
-echo "==> Administrator password required for setup."
-sudo -v
-while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
-SUDO_KEEPALIVE_PID=$!
-trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT
+# sudo が存在しない環境ではスキップする。
+if command -v sudo &>/dev/null; then
+    echo "==> Administrator password required for setup."
+    sudo -v
+    while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
+    SUDO_KEEPALIVE_PID=$!
+    trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT
+fi
 
 # ── Xcode Command Line Tools ────────────────────────────────────
 if ! xcode-select -p &>/dev/null; then


### PR DESCRIPTION
## Summary
This PR improves the setup experience by preventing repeated sudo password prompts during installation, and reorganizes the 1password package installation to use the appropriate installation method for each platform.

## Key Changes
- **Add sudo keepalive mechanism** to both `setup.sh` and `run_onchange_before_install-packages.sh.tmpl`
  - Authenticates once at the start of setup/installation
  - Maintains sudo session in the background by refreshing the timestamp every 50 seconds
  - Automatically cleans up the background process on script exit using a trap handler
  - Includes Japanese documentation explaining the purpose and pattern reference

- **Reorganize 1password installation** in Brewfile
  - Move `1password-cli` from generic `brew` formula to macOS-specific `cask` installation
  - Keep `1password` GUI app as a cask under the macOS-specific section
  - Ensures the CLI tool is only installed on macOS where it's needed

## Implementation Details
The sudo keepalive pattern follows the approach used by Homebrew's install script and mathiasbynens/dotfiles. The background loop exits gracefully if the parent process terminates, and the trap ensures cleanup even if the script exits unexpectedly.

https://claude.ai/code/session_016VE7dKTAvoUuFtDFqkYTNF