### PR TITLE
fix: Ghostty の無効な theme 設定を削除

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,13 +2,6 @@ name: Validate
 
 on:
   pull_request:
-    paths:
-      - Brewfile
-      - .chezmoi.yaml.tmpl
-      - "*.tmpl"
-      - "dot_*"
-      - "private_dot_*"
-      - "run_*"
 
 jobs:
   brewfile:

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,2 +1,1 @@
 font-size = 14
-theme = light:GhosttyLight,dark:GhosttyDark

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,2 +1,2 @@
 font-size = 14
-theme = auto
+theme = light:GhosttyLight,dark:GhosttyDark


### PR DESCRIPTION
## Summary
- Ghostty の `theme = auto` が無効な値のため起動時にエラーが発生していた
- `theme` 行を削除し、Ghostty のデフォルトテーマに任せるよう修正

## Test plan
- [ ] Ghostty を起動して Configuration Errors ダイアログが表示されないことを確認
- [ ] テーマが正常に適用されていることを確認

https://claude.ai/code/session_014R5TpVENpn9Kee3M42Bo44

---
_Generated by [Claude Code](https://claude.ai/code/session_014R5TpVENpn9Kee3M42Bo44)_