### PR TITLE
feat: スクリーンショットのデフォルト保存先をクリップボードに (#86)

### DIFF
--- a/run_onchange_after_macos-defaults.sh.tmpl
+++ b/run_onchange_after_macos-defaults.sh.tmpl
@@ -2,30 +2,50 @@
 {{ if eq .chezmoi.os "darwin" -}}
 set -euo pipefail
 
-# ─── Dock ───
-defaults write com.apple.dock autohide -bool true
-defaults write com.apple.dock mru-spaces -bool false
-defaults write com.apple.dock show-recents -bool false
+# macOS の各種デフォルト設定を宣言的に管理する。
+# 設定を追加するときは SETTINGS と RESTART_APPS を編集するだけでよい。
+#
+# SETTINGS の形式:
+#   "<domain>|<key>|<type>|<value>"
+#     domain: NSGlobalDomain や com.apple.* などの defaults ドメイン
+#     type:   bool | int | float | string（`defaults write -<type>` に渡る）
+#     value:  設定値。string の場合はそのまま文字列として書き込む。
+#
+# RESTART_APPS: 設定反映に再起動が必要なプロセス名の一覧。
+#   - Dock / Finder: Dock と Finder の見た目/挙動変更の反映
+#   - SystemUIServer: メニューバー・スクリーンショット挙動等の反映
 
-# ─── Finder ───
-defaults write com.apple.finder AppleShowAllExtensions -bool true
-defaults write com.apple.finder FXPreferredViewStyle -string "clmv"
-defaults write com.apple.finder ShowPathbar -bool true
-defaults write com.apple.finder ShowStatusBar -bool true
+SETTINGS=(
+  # ─── Dock ───
+  "com.apple.dock|autohide|bool|true"
+  "com.apple.dock|mru-spaces|bool|false"
+  "com.apple.dock|show-recents|bool|false"
 
-# ─── Keyboard ───
-# InitialKeyRepeat: キー入力開始までの遅延（10 = 最速、GUI最速は15）
-# KeyRepeat: キーリピート間隔（1 = 最速、GUI最速は2）
-defaults write NSGlobalDomain InitialKeyRepeat -int 10
-defaults write NSGlobalDomain KeyRepeat -int 1
+  # ─── Finder ───
+  "com.apple.finder|AppleShowAllExtensions|bool|true"
+  "com.apple.finder|FXPreferredViewStyle|string|clmv"
+  "com.apple.finder|ShowPathbar|bool|true"
+  "com.apple.finder|ShowStatusBar|bool|true"
 
-# ─── Screenshot ───
-# target: スクリーンショットの保存先を "clipboard" にすることで、
-# ファイル保存ではなくクリップボードへ直接コピーする。
-# 撮影後すぐに貼り付けて使うケースが多いため、デスクトップに画像が
-# 溜まらないようにするのが目的。
-# 値: file | clipboard | preview | mail
-defaults write com.apple.screencapture target -string "clipboard"
+  # ─── Keyboard ───
+  # InitialKeyRepeat: キー入力開始までの遅延（10 = 最速、GUI最速は15）
+  # KeyRepeat: キーリピート間隔（1 = 最速、GUI最速は2）
+  "NSGlobalDomain|InitialKeyRepeat|int|10"
+  "NSGlobalDomain|KeyRepeat|int|1"
 
-killall Dock Finder SystemUIServer 2>/dev/null || true
+  # ─── Screenshot ───
+  # target: 撮影後すぐに貼り付ける運用を前提に、保存先をクリップボードに固定。
+  # デスクトップに画像ファイルが溜まらないようにするのが目的。
+  # 値: file | clipboard | preview | mail
+  "com.apple.screencapture|target|string|clipboard"
+)
+
+RESTART_APPS=(Dock Finder SystemUIServer)
+
+for entry in "${SETTINGS[@]}"; do
+  IFS='|' read -r domain key type value <<< "$entry"
+  defaults write "$domain" "$key" "-$type" "$value"
+done
+
+killall "${RESTART_APPS[@]}" 2>/dev/null || true
 {{ end -}}

--- a/run_onchange_after_macos-defaults.sh.tmpl
+++ b/run_onchange_after_macos-defaults.sh.tmpl
@@ -19,5 +19,13 @@ defaults write com.apple.finder ShowStatusBar -bool true
 defaults write NSGlobalDomain InitialKeyRepeat -int 10
 defaults write NSGlobalDomain KeyRepeat -int 1
 
-killall Dock Finder 2>/dev/null || true
+# ─── Screenshot ───
+# target: スクリーンショットの保存先を "clipboard" にすることで、
+# ファイル保存ではなくクリップボードへ直接コピーする。
+# 撮影後すぐに貼り付けて使うケースが多いため、デスクトップに画像が
+# 溜まらないようにするのが目的。
+# 値: file | clipboard | preview | mail
+defaults write com.apple.screencapture target -string "clipboard"
+
+killall Dock Finder SystemUIServer 2>/dev/null || true
 {{ end -}}


### PR DESCRIPTION
## Summary

- スクリーンショットの保存先をファイル（デスクトップ）ではなくクリップボードに変更（`com.apple.screencapture target = clipboard`）。撮影後そのまま貼り付けて使う運用を前提に、デスクトップに画像が溜まらないようにする。
- 設定反映に `SystemUIServer` の再起動が必要なため `killall` 対象に追加。
- ついでに `run_onchange_after_macos-defaults.sh.tmpl` を宣言的（データ駆動）な構成にリファクタ。設定を `SETTINGS` 配列（`domain|key|type|value`）で宣言し、ループで `defaults write` に流す。`killall` 対象も `RESTART_APPS` で宣言。

Closes #86

## Test plan

- [ ] macOS 上で `chezmoi apply` を実行し、エラーなく完了すること
- [ ] `defaults read com.apple.screencapture target` が `clipboard` を返すこと
- [ ] ⌘⇧3 / ⌘⇧4 で撮影した直後、ファイルが作成されず、任意のアプリで ⌘V で画像として貼り付けできること
- [ ] 既存の Dock / Finder / キーリピート設定が従来どおり適用されていること
- [ ] `.github/workflows/validate.yml` の chezmoi テンプレート検証が pass すること


---
_Generated by [Claude Code](https://claude.ai/code/session_01X2KnnUvVVx7AcAb2cVGTfH)_