### PR TITLE
fix(setup): 1Password を自動 bootstrap し未サインイン時は fail-fast

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -18,10 +18,16 @@
        通常は setup.sh が Homebrew / 1Password / op の bootstrap と
        サインインチェックを済ませてから chezmoi を起動する。
        ここのチェックは `chezmoi init tktcorporation` を直接叩いた人向けの保険。
-       op バイナリ存在 && サインイン済みアカウントあり の二条件。 */ -}}
-{{- $opStatus := output "sh" "-c" "command -v op >/dev/null 2>&1 && op account list </dev/null 2>/dev/null | grep -q . && echo ok || echo missing" | trim -}}
+       なお chezmoi の仕様上、このファイルは `chezmoi init` 時のみ評価され、
+       通常の `chezmoi apply` / `chezmoi update` では再評価されない
+       (https://www.chezmoi.io/reference/commands/init/)。
+
+       op バイナリ存在 && アクティブなサインイン中 の二条件。
+       `op whoami` を使うのは、`op account list` だと「設定済みだがサインアウト中」
+       が ok 判定されてしまうため (PR #89 Codex review)。 */ -}}
+{{- $opStatus := output "sh" "-c" "command -v op >/dev/null 2>&1 && op whoami </dev/null >/dev/null 2>&1 && echo ok || echo missing" | trim -}}
 {{- if ne $opStatus "ok" -}}
-{{-   writeToStderr "\n==> ERROR: 1Password CLI が利用できないため chezmoi を続行できません。\n\n   推奨: setup.sh 経由で実行してください (bootstrap 込みで一気通貫):\n     bash <(curl -fsLS https://raw.githubusercontent.com/tktcorporation/dotfiles/main/setup.sh)\n\n   個別に準備する場合は:\n     - 1Password アプリと CLI をインストール (brew install --cask 1password 1password-cli)\n     - 1Password アプリで Settings → Developer → CLI 統合 ON\n     - op account list でアカウントが見えることを確認\n\n" -}}
+{{-   writeToStderr "\n==> ERROR: 1Password CLI が利用できないため chezmoi を続行できません。\n\n   推奨: setup.sh 経由で実行してください (bootstrap 込みで一気通貫):\n     bash <(curl -fsLS https://raw.githubusercontent.com/tktcorporation/dotfiles/main/setup.sh)\n\n   個別に準備する場合は:\n     - 1Password アプリと CLI をインストール (brew install --cask 1password 1password-cli)\n     - 1Password アプリで Settings → Developer → CLI 統合 ON\n     - op whoami でアクティブなサインインがあることを確認\n\n" -}}
 {{-   fail "1Password unavailable; aborting chezmoi template processing." -}}
 {{- end -}}
 

--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -15,8 +15,12 @@
 {{- end -}}
 
 {{- /* ─── SSH signing key from 1Password ─── */ -}}
+{{- /* stdin を /dev/null に向けないと、未サインイン環境で op が
+       「Do you want to add an account manually now?」の対話に入り
+       chezmoi が stdin を待って止まってしまう。
+       2>/dev/null で案内メッセージも抑止する。 */ -}}
 {{- $signingkey := "" -}}
-{{- $detectedKey := output "sh" "-c" "op item get 'Github SSHキー' --account my.1password.com --fields public_key 2>/dev/null || true" | trim -}}
+{{- $detectedKey := output "sh" "-c" "op item get 'Github SSHキー' --account my.1password.com --fields public_key </dev/null 2>/dev/null || true" | trim -}}
 {{- if $detectedKey -}}
 {{-   $useKey := promptBoolOnce . "useDetectedKey" (printf "Use this SSH key for commit signing?\n  %s" $detectedKey) -}}
 {{-   if $useKey -}}

--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -15,13 +15,13 @@
 {{- end -}}
 
 {{- /* ─── 1Password pre-flight (defense in depth) ─────────────
-       通常は setup.sh の check_1password() で先に弾かれる。
-       ここは `chezmoi init tktcorporation` を直接叩いた場合の保険。
-       チェックは「op バイナリ存在 && サインイン済みアカウントあり」の二段。
-       echo の出力が "ok" でなければ fail する。 */ -}}
+       通常は setup.sh が Homebrew / 1Password / op の bootstrap と
+       サインインチェックを済ませてから chezmoi を起動する。
+       ここのチェックは `chezmoi init tktcorporation` を直接叩いた人向けの保険。
+       op バイナリ存在 && サインイン済みアカウントあり の二条件。 */ -}}
 {{- $opStatus := output "sh" "-c" "command -v op >/dev/null 2>&1 && op account list </dev/null 2>/dev/null | grep -q . && echo ok || echo missing" | trim -}}
 {{- if ne $opStatus "ok" -}}
-{{-   writeToStderr "\n==> ERROR: 1Password CLI が利用できません (未インストール or 未サインイン)\n\n   復旧手順は setup.sh の check_1password() のメッセージを参照、\n   または:\n     - インストール: brew install --cask 1password 1password-cli\n     - サインイン: 1Password アプリ → Settings → Developer → CLI 統合 ON\n\n" -}}
+{{-   writeToStderr "\n==> ERROR: 1Password CLI が利用できないため chezmoi を続行できません。\n\n   推奨: setup.sh 経由で実行してください (bootstrap 込みで一気通貫):\n     bash <(curl -fsLS https://raw.githubusercontent.com/tktcorporation/dotfiles/main/setup.sh)\n\n   個別に準備する場合は:\n     - 1Password アプリと CLI をインストール (brew install --cask 1password 1password-cli)\n     - 1Password アプリで Settings → Developer → CLI 統合 ON\n     - op account list でアカウントが見えることを確認\n\n" -}}
 {{-   fail "1Password unavailable; aborting chezmoi template processing." -}}
 {{- end -}}
 

--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -14,11 +14,21 @@
 {{-   $email = promptStringOnce . "email" "Git email address" -}}
 {{- end -}}
 
+{{- /* ─── 1Password pre-flight (defense in depth) ─────────────
+       通常は setup.sh の check_1password() で先に弾かれる。
+       ここは `chezmoi init tktcorporation` を直接叩いた場合の保険。
+       チェックは「op バイナリ存在 && サインイン済みアカウントあり」の二段。
+       echo の出力が "ok" でなければ fail する。 */ -}}
+{{- $opStatus := output "sh" "-c" "command -v op >/dev/null 2>&1 && op account list </dev/null 2>/dev/null | grep -q . && echo ok || echo missing" | trim -}}
+{{- if ne $opStatus "ok" -}}
+{{-   writeToStderr "\n==> ERROR: 1Password CLI が利用できません (未インストール or 未サインイン)\n\n   復旧手順は setup.sh の check_1password() のメッセージを参照、\n   または:\n     - インストール: brew install --cask 1password 1password-cli\n     - サインイン: 1Password アプリ → Settings → Developer → CLI 統合 ON\n\n" -}}
+{{-   fail "1Password unavailable; aborting chezmoi template processing." -}}
+{{- end -}}
+
 {{- /* ─── SSH signing key from 1Password ─── */ -}}
-{{- /* stdin を /dev/null に向けないと、未サインイン環境で op が
-       「Do you want to add an account manually now?」の対話に入り
-       chezmoi が stdin を待って止まってしまう。
-       2>/dev/null で案内メッセージも抑止する。 */ -}}
+{{- /* ここに到達した時点で op はサインイン済みが保証されている。
+       それでもアイテムが見つからない可能性はあるので || true は残す。
+       stdin /dev/null は op の対話プロンプト防止（保険）。 */ -}}
 {{- $signingkey := "" -}}
 {{- $detectedKey := output "sh" "-c" "op item get 'Github SSHキー' --account my.1password.com --fields public_key </dev/null 2>/dev/null || true" | trim -}}
 {{- if $detectedKey -}}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -2,6 +2,7 @@ Brewfile
 README.md
 LICENSE.txt
 setup.sh
+scripts
 .editorconfig
 .github
 .gitignore

--- a/run_onchange_before_install-packages.sh.tmpl
+++ b/run_onchange_before_install-packages.sh.tmpl
@@ -1,48 +1,32 @@
 #!/bin/bash
 set -euo pipefail
 
+# 再実行トリガー: Brewfile または共通ライブラリが変わったら chezmoi が再走させる。
 # Brewfile hash: {{ include "Brewfile" | sha256sum }}
+# Bootstrap lib hash: {{ include "scripts/bootstrap-lib.sh" | sha256sum }}
+
+# ── 共通 bootstrap ライブラリを読み込む ─────────────────────────
+# sudo keepalive / Homebrew インストール / PATH 設定 を setup.sh と共有する。
+# shellcheck source=scripts/bootstrap-lib.sh
+source "{{ joinPath .chezmoi.sourceDir "scripts" "bootstrap-lib.sh" }}"
 
 # ── クリーンアップ ──────────────────────────────────────────────
-# 複数のリソース（sudo keepalive プロセス、一時ファイル）を
-# 一つの trap ハンドラでまとめて掃除する。
-SUDO_KEEPALIVE_PID=""
+# sudo keepalive プロセスと一時 Brewfile を一つの trap でまとめて掃除する。
 TMPBREWFILE=""
 cleanup() {
-    [ -n "$SUDO_KEEPALIVE_PID" ] && kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+    [ -n "${SUDO_KEEPALIVE_PID:-}" ] && kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
     [ -n "$TMPBREWFILE" ] && rm -f "$TMPBREWFILE"
 }
 trap cleanup EXIT
 
 # ── sudo keepalive ──────────────────────────────────────────────
-# Homebrew のインストールや cask のインストール時に何度も
-# パスワードを求められるのを防ぐため、最初に1回だけ認証し
-# バックグラウンドでタイムスタンプを更新し続ける。
-# パターンは Homebrew install.sh / mathiasbynens/dotfiles を参考。
-# sudo が存在しない環境や、sudoers に入っていない環境
-# （Linuxbrew 非 root、CI コンテナ等）ではスキップする。
-if command -v sudo &>/dev/null; then
-    echo "==> macOS のパスワードを入力してください（sudo 認証・この1回のみ）"
-    if sudo -v 2>/dev/null; then
-        while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
-        SUDO_KEEPALIVE_PID=$!
-    fi
-fi
+# setup.sh 経由ならここでは再認証プロンプトが出ない (credential が新鮮)。
+# chezmoi apply を手動実行する場合はここで初めてパスワードを聞かれる。
+echo "==> macOS のパスワードを入力してください（sudo 認証・この1回のみ）"
+start_sudo_keepalive
 
-# Install Homebrew if not present
-if ! command -v brew &>/dev/null; then
-    echo "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-    # Add brew to PATH for this session
-    if [[ -f /opt/homebrew/bin/brew ]]; then
-        eval "$(/opt/homebrew/bin/brew shellenv)"
-    elif [[ -f /usr/local/bin/brew ]]; then
-        eval "$(/usr/local/bin/brew shellenv)"
-    elif [[ -f /home/linuxbrew/.linuxbrew/bin/brew ]]; then
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-    fi
-fi
+install_homebrew_if_missing
+load_brew_shellenv
 
 # ── mas (Mac App Store) サインイン状態チェック ──────────────────
 # mas install は Apple ID 認証（sudo とは別）が必要。

--- a/scripts/bootstrap-lib.sh
+++ b/scripts/bootstrap-lib.sh
@@ -37,11 +37,25 @@ start_sudo_keepalive() {
 
 # Homebrew が未インストールなら公式 installer を実行する。
 # 既にインストール済みなら何もしない (idempotent)。
+#
+# 「インストール済み」の判定は 2 段階:
+#   1. PATH 経由で `brew` コマンドが見える (普通の対話 shell)
+#   2. 既知のインストールパスにバイナリが存在 (PATH 未設定の非対話 shell 向け)
+#
+# 2 を入れている理由: bash <(curl ...) 経由の非ログイン shell では PATH に
+# /opt/homebrew/bin が入っていない場合があり、command -v brew だけだと
+# 「既に入っているのに再インストール」してしまう (PR #89 Codex review)。
 install_homebrew_if_missing() {
-    if ! command -v brew >/dev/null 2>&1; then
-        echo "==> Installing Homebrew..."
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    if command -v brew >/dev/null 2>&1; then
+        return
     fi
+    if [ -x /opt/homebrew/bin/brew ] \
+        || [ -x /usr/local/bin/brew ] \
+        || [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+        return
+    fi
+    echo "==> Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 }
 
 # brew を現在シェルセッションの PATH に通す。

--- a/scripts/bootstrap-lib.sh
+++ b/scripts/bootstrap-lib.sh
@@ -1,0 +1,58 @@
+# setup.sh と run_onchange_before_install-packages.sh が共用する
+# ブートストラップ関数群。sudo keepalive、Homebrew インストール、
+# PATH 設定といった「セットアップ最初期の小道具」を SSOT で集約する。
+#
+# 読み込み方:
+#
+#   setup.sh 側 (curl|bash でリポジトリが未クローンの段階):
+#     LIB_URL="https://raw.githubusercontent.com/tktcorporation/dotfiles/main/scripts/bootstrap-lib.sh"
+#     LIB_TMP=$(mktemp)
+#     curl -fsSL "$LIB_URL" -o "$LIB_TMP"
+#     # shellcheck source=/dev/null
+#     source "$LIB_TMP" && rm -f "$LIB_TMP"
+#
+#   run_onchange_*.sh.tmpl 側 (chezmoi sourceDir が既にある):
+#     source "{{ joinPath .chezmoi.sourceDir "scripts" "bootstrap-lib.sh" }}"
+#
+# 注意: このファイル自体はシェルスクリプトとして `bash -n` で構文検査可能だが
+# 単体で実行するものではない。関数定義しか含まないので source されて使われる。
+
+# sudo を事前認証してバックグラウンドで維持する。
+# セットアップ中に複数の sudo コマンドが走ってもパスワード入力を
+# 求められないようにする (ヘッドレス実行でも通るようにするため)。
+#
+# グローバル変数 $SUDO_KEEPALIVE_PID に PID を設定するので、呼び出し側は
+# 次のように trap でクリーンアップすること:
+#   trap 'kill "${SUDO_KEEPALIVE_PID:-}" 2>/dev/null || true' EXIT
+#
+# sudo が無い or sudoers に入っていない (Linuxbrew 非 root、CI コンテナ等)
+# の環境では何もせずに返る。
+start_sudo_keepalive() {
+    SUDO_KEEPALIVE_PID=""
+    if command -v sudo >/dev/null 2>&1 && sudo -v 2>/dev/null; then
+        while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
+        SUDO_KEEPALIVE_PID=$!
+    fi
+}
+
+# Homebrew が未インストールなら公式 installer を実行する。
+# 既にインストール済みなら何もしない (idempotent)。
+install_homebrew_if_missing() {
+    if ! command -v brew >/dev/null 2>&1; then
+        echo "==> Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
+}
+
+# brew を現在シェルセッションの PATH に通す。
+# Homebrew インストール直後や、shellenv を evaluate していない環境で必要。
+# Apple Silicon Mac / Intel Mac / Linuxbrew の 3 配置に対応する。
+load_brew_shellenv() {
+    if [ -x /opt/homebrew/bin/brew ]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [ -x /usr/local/bin/brew ]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    elif [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+    fi
+}

--- a/setup.sh
+++ b/setup.sh
@@ -73,65 +73,78 @@ else
     echo "==> Xcode Command Line Tools already installed."
 fi
 
-# ── 1Password pre-flight ────────────────────────────────────────
+# ── 1Password bootstrap ─────────────────────────────────────────
 # .chezmoi.yaml.tmpl と dot_gitconfig.tmpl が 1Password に依存しているため、
-# chezmoi が走る前にここで早期検出して、何が足りないかを具体的に伝える。
+# chezmoi が走る前にここで最小限の bootstrap を済ませる:
+#   1. Homebrew を用意 (なければインストール)
+#   2. 1Password アプリ (GUI) が無ければ cask で入れる (既存インストールは尊重)
+#   3. 1Password CLI (op) が無ければ cask で入れる
+#   4. サインイン状態をチェック。未サインインなら復旧手順を出して exit 1
 #
-# 「黙って degrade」ではなく fail-fast にする方針。
-# 過去に「op 未サインイン → signingkey が無音で空 → 数日後にコミット署名されてないと気付く」
-# という事故があったため、最初に止めて気付かせる。
+# 残りの Brewfile 全体は chezmoi apply 中に run_onchange_before_install-packages.sh
+# が適用する。ここで入れる 2 つは後段で no-op になるだけ (idempotent)。
+#
+# 「op が未準備なら無音 degrade」から「fail-fast with guidance」への方針転換。
 
-check_1password() {
-    # ── Case 1: op バイナリ未インストール ──────────────────────
-    if ! command -v op >/dev/null 2>&1; then
-        cat >&2 <<'EOF'
+# Homebrew
+if ! command -v brew >/dev/null 2>&1; then
+    echo "==> Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
 
-==> ERROR: 1Password CLI (op) が見つかりません
+# brew を現在セッションの PATH に通す (Apple Silicon / Intel 両対応)
+# Homebrew インストール直後は PATH に入っていないため明示的に設定する。
+if [ -x /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x /usr/local/bin/brew ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+fi
 
-このセットアップは Git コミット署名のために 1Password を必須にしています。
+# 1Password アプリ (GUI): 既存の /Applications/1Password.app を尊重。
+# Mac App Store や公式 DMG で入れた場合と衝突しないよう、ディレクトリの
+# 有無で判定してから cask インストールする。
+if [ ! -d /Applications/1Password.app ]; then
+    echo "==> Installing 1Password (app)..."
+    brew install --cask 1password
+fi
 
-▶ 復旧手順:
-  1. 1Password アプリをインストール (まだなら):
-       https://1password.com/downloads/mac/
-  2. 1Password CLI をインストール:
-       brew install --cask 1password-cli
-  3. 1Password アプリにサインイン後、
-       Settings → Developer → "Integrate with 1Password CLI" を ON
-  4. ターミナル再起動後、もう一度 setup.sh を実行
+# 1Password CLI (op)
+if ! command -v op >/dev/null 2>&1; then
+    echo "==> Installing 1Password CLI..."
+    brew install --cask 1password-cli
+fi
 
-EOF
-        exit 1
-    fi
+# ── 1Password サインイン状態チェック (ユーザー操作必須) ────────
+# op バイナリまでは自動で揃えられるが、サインインはユーザーにしか
+# できない。未サインインなら明確な手順を示して止める。
+#
+# `op account list` は 未サインインだと空出力で exit 0 を返すため
+# `grep -q .` で「1行でも出るか」を判定する。`</dev/null` は op が
+# 対話プロンプト (Do you want to add an account manually now?) に
+# 入るのを防ぐためのガード。
+if ! op account list </dev/null 2>/dev/null | grep -q .; then
+    cat >&2 <<'EOF'
 
-    # ── Case 2: op はあるが、サインイン済みアカウントなし ─────
-    # `op account list` は サインイン済みアカウントが無いと空行を返す。
-    # </dev/null で "Do you want to add an account manually now?" の対話に入るのを防ぐ。
-    if ! op account list </dev/null 2>/dev/null | grep -q .; then
-        cat >&2 <<'EOF'
+==> 1Password にサインインしてください
 
-==> ERROR: 1Password CLI が未サインインです
+1Password アプリと CLI は準備できました。最後のひと手間として、
+サインインが必要です。chezmoi はここから SSH 署名キーを取得します。
 
-▶ 復旧手順:
-  方法A (推奨): 1Password アプリ統合を有効化
-       1. 1Password アプリ → Settings → Developer
-       2. "Integrate with 1Password CLI" を ON
-       3. ターミナル再起動
+▶ やること:
+  1. 1Password アプリを起動してサインイン
+  2. アプリ内 Settings → Developer → "Integrate with 1Password CLI" を ON
+  3. ターミナルを開き直す (shellenv 再読込のため)
+  4. 確認:
+       op account list   # アカウントが表示されればOK
+  5. もう一度 setup.sh を実行
 
-  方法B: コマンドラインで手動サインイン
+補足: GUI を使わず CLI だけでサインインしたい場合は:
        op account add
        op signin
 
-  確認:
-       op account list   # アカウントが表示されればOK
-
-その後もう一度 setup.sh を実行してください。
-
 EOF
-        exit 1
-    fi
-}
-
-check_1password
+    exit 1
+fi
 
 # ── chezmoi init & apply ────────────────────────────────────────
 echo "==> Installing chezmoi and applying dotfiles..."

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,22 @@ fi
 # shellcheck source=/dev/null
 source "$BOOTSTRAP_LIB_TMP"
 
+# ライブラリが期待通り読めたかを検証する。
+# setup.sh と bootstrap-lib.sh は別々に curl で取得されるため、
+# 万が一両者のリビジョンがズレて関数が消えていた場合、ここで明確に止める。
+# (See PR #89 review: pin bootstrap-lib fetch to the same setup.sh revision)
+for fn in start_sudo_keepalive install_homebrew_if_missing load_brew_shellenv; do
+    if ! declare -F "$fn" >/dev/null; then
+        cat >&2 <<EOF
+ERROR: Bootstrap library is missing expected function: $fn
+       setup.sh と bootstrap-lib.sh のリビジョンがズレた可能性があります。
+       数秒待って再実行するか、BOOTSTRAP_LIB_URL を特定コミットに固定してください。
+       Source: $BOOTSTRAP_LIB_URL
+EOF
+        exit 1
+    fi
+done
+
 # ── sudo keepalive ──────────────────────────────────────────────
 start_sudo_keepalive
 trap 'kill "${SUDO_KEEPALIVE_PID:-}" 2>/dev/null || true; rm -f "$BOOTSTRAP_LIB_TMP"' EXIT

--- a/setup.sh
+++ b/setup.sh
@@ -3,15 +3,24 @@ set -euo pipefail
 
 echo "==> dotfiles setup"
 
-# ── sudo keepalive ──────────────────────────────────────────────
-# セットアップ中に何度もパスワードを求められるのを防ぐため、
-# 最初に1回だけ認証しバックグラウンドでタイムスタンプを更新し続ける。
-# sudo が存在しない環境や、sudoers に入っていない環境ではスキップする。
-if command -v sudo &>/dev/null && sudo -v 2>/dev/null; then
-    while true; do sudo -n true; sleep 50; kill -0 "$$" || exit; done 2>/dev/null &
-    SUDO_KEEPALIVE_PID=$!
-    trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT
+# ── 共通 bootstrap ライブラリを取得 ─────────────────────────────
+# setup.sh は curl|bash で実行されるため、この時点でリポジトリは未クローン。
+# 共通関数 (sudo keepalive、Homebrew インストール、PATH 設定) を
+# リモートから取って source する。run_onchange スクリプトも同じファイルを
+# source するので SSOT が保たれる。
+BOOTSTRAP_LIB_URL="${BOOTSTRAP_LIB_URL:-https://raw.githubusercontent.com/tktcorporation/dotfiles/main/scripts/bootstrap-lib.sh}"
+BOOTSTRAP_LIB_TMP=$(mktemp)
+trap 'rm -f "$BOOTSTRAP_LIB_TMP"' EXIT
+if ! curl -fsSL "$BOOTSTRAP_LIB_URL" -o "$BOOTSTRAP_LIB_TMP"; then
+    echo "ERROR: Failed to fetch bootstrap library from $BOOTSTRAP_LIB_URL" >&2
+    exit 1
 fi
+# shellcheck source=/dev/null
+source "$BOOTSTRAP_LIB_TMP"
+
+# ── sudo keepalive ──────────────────────────────────────────────
+start_sudo_keepalive
+trap 'kill "${SUDO_KEEPALIVE_PID:-}" 2>/dev/null || true; rm -f "$BOOTSTRAP_LIB_TMP"' EXIT
 
 # ── Xcode Command Line Tools ────────────────────────────────────
 if ! xcode-select -p &>/dev/null; then
@@ -86,19 +95,8 @@ fi
 #
 # 「op が未準備なら無音 degrade」から「fail-fast with guidance」への方針転換。
 
-# Homebrew
-if ! command -v brew >/dev/null 2>&1; then
-    echo "==> Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-fi
-
-# brew を現在セッションの PATH に通す (Apple Silicon / Intel 両対応)
-# Homebrew インストール直後は PATH に入っていないため明示的に設定する。
-if [ -x /opt/homebrew/bin/brew ]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-elif [ -x /usr/local/bin/brew ]; then
-    eval "$(/usr/local/bin/brew shellenv)"
-fi
+install_homebrew_if_missing
+load_brew_shellenv
 
 # 1Password アプリ (GUI): 既存の /Applications/1Password.app を尊重。
 # Mac App Store や公式 DMG で入れた場合と衝突しないよう、ディレクトリの

--- a/setup.sh
+++ b/setup.sh
@@ -132,11 +132,12 @@ fi
 # op バイナリまでは自動で揃えられるが、サインインはユーザーにしか
 # できない。未サインインなら明確な手順を示して止める。
 #
-# `op account list` は 未サインインだと空出力で exit 0 を返すため
-# `grep -q .` で「1行でも出るか」を判定する。`</dev/null` は op が
-# 対話プロンプト (Do you want to add an account manually now?) に
-# 入るのを防ぐためのガード。
-if ! op account list </dev/null 2>/dev/null | grep -q .; then
+# `op whoami` は **認証必須** のコマンドなので、サインアウト中や
+# セッション失効中なら exit 非ゼロで失敗する。`op account list` は
+# 「アカウント設定の有無」しか確認しないため、サインアウト中でも通って
+# しまう (PR #89 Codex review で指摘) ため使わない。
+# </dev/null は op が対話プロンプトに入るのを防ぐためのガード。
+if ! op whoami </dev/null >/dev/null 2>&1; then
     cat >&2 <<'EOF'
 
 ==> 1Password にサインインしてください
@@ -149,7 +150,7 @@ if ! op account list </dev/null 2>/dev/null | grep -q .; then
   2. アプリ内 Settings → Developer → "Integrate with 1Password CLI" を ON
   3. ターミナルを開き直す (shellenv 再読込のため)
   4. 確認:
-       op account list   # アカウントが表示されればOK
+       op whoami         # アカウント情報が表示されればOK (アクティブなセッションが必要)
   5. もう一度 setup.sh を実行
 
 補足: GUI を使わず CLI だけでサインインしたい場合は:

--- a/setup.sh
+++ b/setup.sh
@@ -73,6 +73,66 @@ else
     echo "==> Xcode Command Line Tools already installed."
 fi
 
+# ── 1Password pre-flight ────────────────────────────────────────
+# .chezmoi.yaml.tmpl と dot_gitconfig.tmpl が 1Password に依存しているため、
+# chezmoi が走る前にここで早期検出して、何が足りないかを具体的に伝える。
+#
+# 「黙って degrade」ではなく fail-fast にする方針。
+# 過去に「op 未サインイン → signingkey が無音で空 → 数日後にコミット署名されてないと気付く」
+# という事故があったため、最初に止めて気付かせる。
+
+check_1password() {
+    # ── Case 1: op バイナリ未インストール ──────────────────────
+    if ! command -v op >/dev/null 2>&1; then
+        cat >&2 <<'EOF'
+
+==> ERROR: 1Password CLI (op) が見つかりません
+
+このセットアップは Git コミット署名のために 1Password を必須にしています。
+
+▶ 復旧手順:
+  1. 1Password アプリをインストール (まだなら):
+       https://1password.com/downloads/mac/
+  2. 1Password CLI をインストール:
+       brew install --cask 1password-cli
+  3. 1Password アプリにサインイン後、
+       Settings → Developer → "Integrate with 1Password CLI" を ON
+  4. ターミナル再起動後、もう一度 setup.sh を実行
+
+EOF
+        exit 1
+    fi
+
+    # ── Case 2: op はあるが、サインイン済みアカウントなし ─────
+    # `op account list` は サインイン済みアカウントが無いと空行を返す。
+    # </dev/null で "Do you want to add an account manually now?" の対話に入るのを防ぐ。
+    if ! op account list </dev/null 2>/dev/null | grep -q .; then
+        cat >&2 <<'EOF'
+
+==> ERROR: 1Password CLI が未サインインです
+
+▶ 復旧手順:
+  方法A (推奨): 1Password アプリ統合を有効化
+       1. 1Password アプリ → Settings → Developer
+       2. "Integrate with 1Password CLI" を ON
+       3. ターミナル再起動
+
+  方法B: コマンドラインで手動サインイン
+       op account add
+       op signin
+
+  確認:
+       op account list   # アカウントが表示されればOK
+
+その後もう一度 setup.sh を実行してください。
+
+EOF
+        exit 1
+    fi
+}
+
+check_1password
+
 # ── chezmoi init & apply ────────────────────────────────────────
 echo "==> Installing chezmoi and applying dotfiles..."
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply tktcorporation


### PR DESCRIPTION
## Summary

`bash <(curl ... setup.sh)` が 1Password CLI (`op`) の対話プロンプトで無言停止する問題を修正し、1Password を setup.sh が自動で bootstrap するようにした。

### 背景

`.chezmoi.yaml.tmpl` は `op item get 'Github SSHキー'` を呼んで SSH 署名キーを自動検出するが、次の経路で壊れていた:

1. **未サインイン時に op が対話プロンプトに入る** → chezmoi が stdin を待って静止
2. `bash <(curl)` 経由の場合は stdin が EOF に達して op が抜け、`|| true` で失敗が握りつぶされ、**無音で signingkey が空のまま展開**される → 数日後に「コミットが署名されていない」ことに気付く

### 修正内容

#### 1. `fix: op が未サインイン環境で対話待ちになる問題を修正`
`op item get` の stdin を `/dev/null` にリダイレクトして、未サインイン環境でも対話に入らないようにした。

#### 2. `feat: 1Password 未準備の場合は fail-fast + 復旧手順を提示`
- `setup.sh` に `check_1password()` を追加。op バイナリ存在 / サインイン状態を別々にチェック。
- `.chezmoi.yaml.tmpl` にも `writeToStderr` + `fail` で同等のガード (直接 `chezmoi init` を叩いた人向けの保険)。
- 未サインイン時は stderr に復旧手順を明示して exit 1 する。

#### 3. `feat: 1Password (app + CLI) を setup.sh で自動インストール`
鶏と卵の問題 (`op` は Brewfile で入るが、chezmoi のテンプレート評価時点ではまだ無い) を解決するため、setup.sh が Xcode CLT 直後に:
- Homebrew (無ければ)
- 1Password アプリ (`/Applications/1Password.app` が無ければ — MAS/DMG の既存インストールは尊重)
- 1Password CLI (`op` が PATH に無ければ)

を bootstrap する。残りの Brewfile は従来通り `run_onchange_before_install-packages.sh.tmpl` で適用 (idempotent に no-op になる)。

#### 4. `refactor: bootstrap ロジックを scripts/bootstrap-lib.sh に集約 (SSOT)`
`setup.sh` と `run_onchange_before_install-packages.sh.tmpl` に重複していた sudo keepalive / Homebrew インストール / brew shellenv を `scripts/bootstrap-lib.sh` の関数として切り出した。

- setup.sh 側: `curl|bash` で実行されるためリポジトリ未クローン → ライブラリもリモートから curl で取得して `source` (BOOTSTRAP_LIB_URL env で上書き可)
- run_onchange 側: `joinPath .chezmoi.sourceDir` でローカル source。`Bootstrap lib hash:` コメントを追加し、ライブラリ変更時に run_onchange が再実行されるようにした。
- `scripts/` を `.chezmoiignore` に追加して chezmoi 管理対象から明示的に除外。

### 新しいフロー

| 状態 | 挙動 |
|---|---|
| 真っ新な Mac | Xcode CLT → Homebrew → 1Password app/CLI 自動インストール → **サインイン待ち (exit 1 + 手順表示)** |
| 1Password を MAS/DMG で既に入れてある | GUI スキップ → op のみ brew で補完 → サインインチェック |
| サインイン済みで再実行 | 全部スキップして chezmoi init --apply へ直行 |

## Test plan

- [ ] 真っ新な Mac (VM) で `bash <(curl ...)` を走らせて、サインイン待ちで止まることを確認
- [ ] サインイン済みの Mac で再実行 → chezmoi apply まで通ることを確認
- [ ] 直接 `chezmoi init tktcorporation` を叩いた場合に template の `fail` が発火することを確認
- [ ] 既存インストールの 1Password (MAS/DMG) がある環境で `brew install --cask 1password` が呼ばれないことを確認
- [ ] `scripts/bootstrap-lib.sh` を編集して `chezmoi apply` したら run_onchange が再走することを確認 (hash コメント経由のトリガー)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RVL6o7hKsLNpmKZJh6P8Lw)_