### PR TITLE
feat: トラックパッド強押しの辞書ポップアップを無効化

### DIFF
--- a/run_onchange_after_macos-defaults.sh.tmpl
+++ b/run_onchange_after_macos-defaults.sh.tmpl
@@ -38,6 +38,14 @@ SETTINGS=(
   # デスクトップに画像ファイルが溜まらないようにするのが目的。
   # 値: file | clipboard | preview | mail
   "com.apple.screencapture|target|string|clipboard"
+
+  # ─── Trackpad ───
+  # com.apple.trackpad.forceClick: テキスト選択中に強く押し込んでしまった際に
+  # 辞書/データ検出のポップアップが出るのを止める。
+  # システム設定の「調べる&データ検出」を「オフ」にしたときに切り替わるキーで、
+  # Force Click 機能全体（ファイルリネーム強押し等）は ForceSuppressed/ActuateDetents
+  # 側で制御されており、こちらは引き続き有効のまま残る。
+  "NSGlobalDomain|com.apple.trackpad.forceClick|bool|false"
 )
 
 RESTART_APPS=(Dock Finder SystemUIServer)


### PR DESCRIPTION
## Summary

- テキスト選択中に Force Click まで押し込んでしまった際に辞書/データ検出のポップアップが出て作業の流れを妨げる問題を解消する。
- `run_onchange_after_macos-defaults.sh.tmpl` の SETTINGS に Trackpad セクションを追加し、`NSGlobalDomain com.apple.trackpad.forceClick = false` を書き込む。
- これはシステム設定「トラックパッド > ポイントとクリック > 調べる&データ検出」を **オフ** にしたときに実際に切り替わるキー。ローカルで System Settings をトグルして defaults の diff を取って確認済み。Force Click 全体（ファイルリネーム強押し等）は `ForceSuppressed` / `ActuateDetents` 側で管理されており、こちらは引き続き有効のまま残る。

## Test plan

- [x] `chezmoi apply` 後、`defaults read NSGlobalDomain com.apple.trackpad.forceClick` が `0` を返す
- [x] `defaults read com.apple.AppleMultitouchTrackpad ForceSuppressed` が `0`（Force Click は有効のまま）
- [x] テキスト選択中の強押しで辞書が出ない
- [x] 他の Force Click 動作（Finder のファイル名強押しリネーム等）は従来どおり動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)