### PR TITLE
feat: USキーボード向け英かな切り替え (Karabiner) を宣言的管理

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -68,6 +68,7 @@ if OS.mac?
   # ─── Input ───
   cask "aqua-voice"
   cask "typeless"
+  cask "karabiner-elements"
 
   # ─── Other ───
   cask "thunderbird"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ dot_zshrc                                    # ~/.zshrc (mise, tool init, aliase
 private_dot_ssh/private_config.tmpl          # ~/.ssh/config (1Password SSH agent + OrbStack)
 dot_config/mise/config.toml                  # ~/.config/mise/config.toml (ランタイム管理)
 dot_config/ghostty/config                    # ~/.config/ghostty/config
+dot_config/karabiner/assets/complex_modifications/cmd-eisuu-kana.json
+                                             # Karabiner: 左右Command 単押しで英数/かな切り替え
 run_onchange_before_install-packages.sh.tmpl # Brewfile 変更時に自動で brew bundle
 run_once_after_macos-defaults.sh.tmpl        # macOS 初回セットアップ時のシステム設定
 run_onchange_after_setup-tools.sh.tmpl       # mise config 変更時にランタイムインストール
@@ -75,6 +77,17 @@ run_onchange_after_setup-tools.sh.tmpl       # mise config 変更時にランタ
 
 - **SSH agent**: `~/.ssh/config` に OS に応じた `IdentityAgent` を自動設定
 - **commit signing**: 初回セットアップ時に SSH 公開鍵を入力すると `op-ssh-sign` 経由の署名を自動設定 (空欄でスキップ可)
+
+## Karabiner-Elements (英かな切り替え)
+
+US キーボードで左右 Command 単押しを 英数 / かな に割り当てる complex modification を `dot_config/karabiner/assets/complex_modifications/cmd-eisuu-kana.json` で配布しています.
+
+初回のみ手動で有効化が必要:
+
+1. Karabiner-Elements を起動し, アクセシビリティ等の権限を付与
+2. Preferences → Complex Modifications → Add predefined rule → "Command 単押しで英数/かな切り替え" を Enable
+
+`~/.config/karabiner/karabiner.json` 本体は GUI 操作で差分が出やすいため意図的に chezmoi 管理外としています.
 
 ## ローカル上書き
 

--- a/dot_config/karabiner/assets/complex_modifications/cmd-eisuu-kana.json
+++ b/dot_config/karabiner/assets/complex_modifications/cmd-eisuu-kana.json
@@ -1,0 +1,28 @@
+{
+  "title": "Command 単押しで英数/かな切り替え (US キーボード向け)",
+  "rules": [
+    {
+      "description": "左Command 単押しで英数、右Command 単押しでかな (他キー併用時は通常の Command として動作)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": { "optional": ["any"] }
+          },
+          "to": [{ "key_code": "left_command", "lazy": true }],
+          "to_if_alone": [{ "key_code": "japanese_eisuu" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": { "optional": ["any"] }
+          },
+          "to": [{ "key_code": "right_command", "lazy": true }],
+          "to_if_alone": [{ "key_code": "japanese_kana" }]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- US キーボード向けに **左Command 単押しで英数 / 右Command 単押しでかな** を切り替える Karabiner-Elements complex modification を chezmoi 管理下に追加.
- `karabiner-elements` cask を Brewfile に追加し `brew bundle` で宣言的にインストールされるようにする.
- README に有効化手順と「`karabiner.json` 本体は GUI 差分が出やすいため管理外」という方針を追記.

## 詳細

- 追加ファイル: `dot_config/karabiner/assets/complex_modifications/cmd-eisuu-kana.json`
  - `to_if_alone` + `lazy: true` のセオリー通りの構成
  - `modifiers: { "optional": ["any"] }` で `Cmd+C` 等の通常ショートカットを破壊しない
- `karabiner.json` 全体は GUI 操作で差分が出やすいため意図的に chezmoi 管理外
- 初回有効化はユーザー操作: Karabiner GUI → Complex Modifications → Add predefined rule → Enable

## Test plan

- [ ] `chezmoi apply` で `~/.config/karabiner/assets/complex_modifications/cmd-eisuu-kana.json` に配置される
- [ ] Karabiner GUI から該当ルールを Enable
- [ ] 左Command 単押し → 英数モードに切り替わる
- [ ] 右Command 単押し → かなモードに切り替わる
- [ ] `Cmd+C` / `Cmd+V` 等が通常通り動作する
- [ ] CI (Validate workflow) が pass する

🤖 Generated with [Claude Code](https://claude.com/claude-code)