### PR TITLE
fix: chezmoi init を止めていた writeToStderr を削除 + CI で未定義関数を検出

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -26,9 +26,11 @@
        `op whoami` を使うのは、`op account list` だと「設定済みだがサインアウト中」
        が ok 判定されてしまうため (PR #89 Codex review)。 */ -}}
 {{- $opStatus := output "sh" "-c" "command -v op >/dev/null 2>&1 && op whoami </dev/null >/dev/null 2>&1 && echo ok || echo missing" | trim -}}
+{{- /* writeToStderr は chezmoi に存在しない関数だったため fail のメッセージに統合。
+       fail はメッセージを stderr に出力して chezmoi を即終了させるので、
+       writeToStderr + fail のセットと同じ効果が一発で得られる。 */ -}}
 {{- if ne $opStatus "ok" -}}
-{{-   writeToStderr "\n==> ERROR: 1Password CLI が利用できないため chezmoi を続行できません。\n\n   推奨: setup.sh 経由で実行してください (bootstrap 込みで一気通貫):\n     bash <(curl -fsLS https://raw.githubusercontent.com/tktcorporation/dotfiles/main/setup.sh)\n\n   個別に準備する場合は:\n     - 1Password アプリと CLI をインストール (brew install --cask 1password 1password-cli)\n     - 1Password アプリで Settings → Developer → CLI 統合 ON\n     - op whoami でアクティブなサインインがあることを確認\n\n" -}}
-{{-   fail "1Password unavailable; aborting chezmoi template processing." -}}
+{{-   fail "\n==> ERROR: 1Password CLI が利用できないため chezmoi を続行できません。\n\n   推奨: setup.sh 経由で実行してください (bootstrap 込みで一気通貫):\n     bash <(curl -fsLS https://raw.githubusercontent.com/tktcorporation/dotfiles/main/setup.sh)\n\n   個別に準備する場合は:\n     - 1Password アプリと CLI をインストール (brew install --cask 1password 1password-cli)\n     - 1Password アプリで Settings → Developer → CLI 統合 ON\n     - op whoami でアクティブなサインインがあることを確認\n" -}}
 {{- end -}}
 
 {{- /* ─── SSH signing key from 1Password ─── */ -}}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,14 +53,11 @@ jobs:
 
       - name: Validate templates (syntax check)
         run: |
-          # chezmoi doctor verifies the source directory is valid
-          # Use --no-pager to avoid interactive output
-          chezmoi --source="$(pwd)" verify 2>&1 || true
-
-          # Basic Go template syntax validation
+          # Basic Go template syntax validation: 開閉ペアの数だけを見る軽量チェック。
+          # 下の execute-template でも実質的にカバーされるが、こちらは chezmoi が
+          # 動かない状況でも単独で機能するので残している。
           errors=0
           for f in $(find . -name '*.tmpl' -not -path './.git/*'); do
-            # Check for unmatched {{ }} pairs (basic syntax validation)
             open_count=$(grep -o '{{' "$f" | wc -l | tr -d ' ')
             close_count=$(grep -o '}}' "$f" | wc -l | tr -d ' ')
             if [ "$open_count" != "$close_count" ]; then
@@ -70,7 +67,30 @@ jobs:
           done
 
           if [ "$errors" -gt 0 ]; then
-            echo "::error::$errors template(s) have syntax issues"
+            echo "::error::$errors template(s) have delimiter mismatch"
             exit 1
           fi
-          echo "All templates validated"
+          echo "All templates have balanced delimiters"
+
+      - name: Validate template execution (detect undefined chezmoi functions)
+        run: |
+          # text/template は関数の存在をパース時に解決するため、未到達ブランチに
+          # 紛れ込んだ未定義関数 (例: かつての writeToStderr) もここで弾ける。
+          # `output` 内で op CLI を呼ぶ箇所は CI 環境では失敗するが、それは
+          # `fail` 等で正常に拾われるエラーで CI fail の対象ではない。
+          # ここでは "function ... not defined" だけを拾って失敗扱いにする。
+          errors=0
+          for f in $(find . -name '*.tmpl' -not -path './.git/*'); do
+            out=$(chezmoi execute-template --init < "$f" 2>&1 || true)
+            if echo "$out" | grep -qE 'function "[^"]+" not defined'; then
+              echo "::error::$f references an undefined chezmoi template function:"
+              echo "$out" | sed 's/^/  /' | head -5
+              errors=$((errors + 1))
+            fi
+          done
+
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::$errors template(s) reference undefined functions"
+            exit 1
+          fi
+          echo "All templates use only known chezmoi functions"


### PR DESCRIPTION
## 問題

\`setup.sh\` 経由で \`chezmoi init\` が走ると以下で停止していた:

\`\`\`
chezmoi: template: chezmoi.yaml:30: function "writeToStderr" not defined
\`\`\`

\`writeToStderr\` は chezmoi のテンプレート関数として存在しない (v2.70.3 で確認). コミット 48a1f0e で導入された.

## 修正 (commit 1: \`fix:\`)

\`writeToStderr\` 呼び出しを削除し, メッセージを \`fail\` の引数に統合した.

\`fail\` は引数の文字列を stderr に出力した上で chezmoi を即終了させるため, 元の \`writeToStderr\` + \`fail\` ペアと同じ効果が一発で得られる. 1Password 未サインイン時の復旧手順をユーザーに見せる挙動はそのまま維持.

## 再発防止 CI (commit 2: \`ci:\`)

\`chezmoi execute-template --init\` を全 \`.tmpl\` に流すステップを Validate ワークフローに追加.

text/template は関数の存在を **パース時** に検査するため, 未到達ブランチに紛れ込んだ未定義関数 (まさに今回の writeToStderr のケース) もまとめて検出できる.

ローカルでの再現確認:
- 修正後の HEAD: 0 件
- HEAD~1 (writeToStderr 残存状態): \`./.chezmoi.yaml.tmpl references an undefined chezmoi template function: chezmoi: template: stdin:30: function "writeToStderr" not defined\` で 1 件検出

副次的整理として, 既存の \`chezmoi --source=. verify 2>&1 || true\` 行はテンプレ検証として機能していなかった (verify は destination 比較で, \`|| true\` で握り潰されていた) ため削除した.

## Test plan

- [x] CI (Validate workflow) pass
- [x] 新CIステップが実行されている (\`All templates use only known chezmoi functions\` がログに出る)
- [ ] op 未サインイン環境で setup.sh を実行 → \`writeToStderr not defined\` ではなく 1Password 復旧手順が表示される
- [ ] op サインイン済み環境で setup.sh を実行 → chezmoi init が最後まで進む

🤖 Generated with [Claude Code](https://claude.com/claude-code)