### PR TITLE
fix: setup.sh で既存 chezmoi source を fast-forward pull する

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -161,6 +161,37 @@ EOF
     exit 1
 fi
 
+# ── 既存 chezmoi source の更新 ──────────────────────────────────
+# `chezmoi init <repo>` は ~/.local/share/chezmoi が既に存在する場合に
+# clone をスキップするが、pull は走らない。setup.sh を再実行した時に
+# 古い source を使い続ける罠 (例: writeToStderr バグ修正後も古い template
+# でコケ続ける) を避けるため、明示的に fast-forward pull する。
+# 未マージのローカル変更や divergent branch がある場合は --ff-only が
+# 失敗するので, 手元のカスタマイズを壊さない安全側に倒している。
+# XDG Base Directory Spec に従う: XDG_DATA_HOME が set なら $XDG_DATA_HOME/chezmoi。
+# chezmoi 本体も同じ規約で source dir を解決するため、ここを揃えないと
+# XDG_DATA_HOME を使っている環境で update が無効になる (Codex review PR #93)。
+CHEZMOI_SOURCE="${XDG_DATA_HOME:-${HOME}/.local/share}/chezmoi"
+if [ -d "$CHEZMOI_SOURCE/.git" ]; then
+    echo "==> Updating existing chezmoi source ($CHEZMOI_SOURCE)..."
+    if ! git -C "$CHEZMOI_SOURCE" pull --ff-only; then
+        cat >&2 <<EOF
+
+==> WARNING: chezmoi source の fast-forward pull に失敗しました
+   $CHEZMOI_SOURCE にローカル変更や divergent commit がある可能性があります。
+   このまま chezmoi init --apply を続けると古いテンプレで処理される恐れがあります。
+
+   復旧手順 (どちらか):
+     A) ローカル変更を整理してから setup.sh を再実行:
+          cd "$CHEZMOI_SOURCE" && git status
+     B) ローカル変更が不要なら source を作り直して setup.sh を再実行:
+          rm -rf "$CHEZMOI_SOURCE"
+
+EOF
+        exit 1
+    fi
+fi
+
 # ── chezmoi init & apply ────────────────────────────────────────
 echo "==> Installing chezmoi and applying dotfiles..."
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply tktcorporation


### PR DESCRIPTION
## 問題

\`bash <(curl ... setup.sh)\` を再実行しても \`~/.local/share/chezmoi\` (or \`\$XDG_DATA_HOME/chezmoi\`) の中身が古いままで、リモートの修正が反映されない。

実例: PR #92 で \`writeToStderr\` を直したが、既に setup.sh を一度走らせて source を clone 済みのユーザーは, マージ後に setup.sh を再実行しても古い template で \`function "writeToStderr" not defined\` で止まり続けた。

原因: \`chezmoi init <repo>\` は source dir が存在する場合 clone をスキップし、pull もしない。

## 修正

\`chezmoi init --apply\` の前に, 既存 source を \`git pull --ff-only\` で更新する。

- **fast-forward only**: ローカル変更や divergent commit があれば失敗させ, 復旧手順を案内 (sourceを勝手に上書きしない)
- **XDG_DATA_HOME 対応**: chezmoi 本体と同じ規約で source dir を解決 (Codex review 指摘)

## 検証

ローカルで以下を確認:

\`\`\`
# シナリオ A: stale clone (HEAD~1) → FF pull で最新に
before pull commit: 7023314 Merge pull request #91 ...
after pull commit:  d74592b Merge pull request #92 ...

# シナリオ B: divergent commit → 復旧手順を出して exit 1
==> WARNING: chezmoi source の fast-forward pull に失敗しました
   ... にローカル変更や divergent commit がある可能性があります。
   復旧手順 (どちらか):
     A) ローカル変更を整理してから setup.sh を再実行: ...
     B) ローカル変更が不要なら source を作り直して setup.sh を再実行: rm -rf ...

# シナリオ C: XDG_DATA_HOME を set した環境でも解決される
resolved: <TMP>/xdg/chezmoi
exists ok
\`\`\`

\`bash -n setup.sh\` 通過。

## Test plan

- [ ] CI (Validate) pass
- [ ] 既に \`~/.local/share/chezmoi\` が clone 済みの環境で setup.sh を再実行 → リモートに追従する
- [ ] ローカル変更がある環境で setup.sh を再実行 → エラーで止まり, 復旧手順が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)