### PR TITLE
feat: Brewfile に clamav を追加

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -25,6 +25,7 @@ brew "exiftool"
 
 # ─── Security & Networking ───
 brew "cloudflared"
+brew "clamav"
 
 if OS.mac?
   # ─── Essentials ───


### PR DESCRIPTION
## Summary
- `Brewfile` の Security & Networking セクションに `brew "clamav"` を追加
- chezmoi の `run_onchange_before_install-packages.sh.tmpl` が Brewfile のハッシュ変更を検知して `brew bundle` を再実行するため、既存マシンで `chezmoi apply` / `chezmoi update` を実行すれば自動的に `clamscan` / `freshclam` が入る

## 動機
- ローカルでウイルススキャンしたい場面のために `clamscan` を宣言的に管理したい
- macOS / Linux 両対応の formula なので `if OS.mac?` の外（共通領域）に配置

## 注意点（手動で必要なこと）
- `clamav` をインストールしただけでは `freshclam.conf` が存在せず、ウイルス定義 DB も空。最初の `clamscan` 実行前に以下が必要:
  ```bash
  cp /opt/homebrew/etc/clamav/freshclam.conf.sample /opt/homebrew/etc/clamav/freshclam.conf
  # freshclam.conf の `Example` 行を削除
  freshclam
  ```
- 自動化は別 PR で検討（`run_onchange_after_*.sh.tmpl` を追加するか、launchd で定期更新するか）

## Test plan
- [x] `brew info clamav` で formula 存在確認（stable 1.5.2 bottled）
- [x] CI の Brewfile validator（`brew info` ループ）が通る前提を満たす
- [ ] CI（validate.yml）の全 job が pass
- [ ] 別マシンで `chezmoi apply` を回し、`clamscan --version` が動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)