### PR TITLE
feat: sudo の Touch ID 認証を setup.sh で有効化

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -38,6 +38,38 @@ done
 start_sudo_keepalive
 trap 'kill "${SUDO_KEEPALIVE_PID:-}" 2>/dev/null || true; rm -f "$BOOTSTRAP_LIB_TMP"' EXIT
 
+# ── Touch ID for sudo ───────────────────────────────────────────
+# brew cask は cask 毎に sudo を発行するため、Touch ID 無効だと
+# install 中にパスワード入力が連発する (Brewfile に cask が 20+ ある現状は煩雑)。
+# macOS Sonoma 以降は /etc/pam.d/sudo_local が OS update でも保持される
+# 追加 PAM 設定として用意されており、pam_tid.so を有効化すれば
+# sudo が Touch ID を受け付ける。
+#
+# 安全性:
+#   - sufficient なので Touch ID 不在/失敗時は通常のパスワード認証に fallthrough
+#   - Touch ID 未登録 / 非対応ハード (Mac mini 等) でも害なし
+#   - sudo_local は OS update でリセットされる /etc/pam.d/sudo とは別ファイル
+if [ -f /etc/pam.d/sudo_local.template ] && \
+   ! sudo -n grep -q '^auth.*pam_tid\.so' /etc/pam.d/sudo_local 2>/dev/null; then
+    echo "==> Enabling Touch ID for sudo (/etc/pam.d/sudo_local)..."
+    # 既存ファイルがあれば中身を維持して append, なければ新規作成。
+    # sudo_local は local customization 用のファイルなので、
+    # ユーザーが他のルールを書いていた場合に破壊しないこと (Codex review PR #96)。
+    if sudo -n test -e /etc/pam.d/sudo_local; then
+        sudo tee -a /etc/pam.d/sudo_local >/dev/null <<'EOF'
+
+# Touch ID for sudo (added by tktcorporation/dotfiles setup.sh)
+auth       sufficient     pam_tid.so
+EOF
+    else
+        sudo tee /etc/pam.d/sudo_local >/dev/null <<'EOF'
+# Managed by tktcorporation/dotfiles setup.sh
+# Touch ID を sudo で使えるようにする。失敗時はパスワード認証にフォールスルー。
+auth       sufficient     pam_tid.so
+EOF
+    fi
+fi
+
 # ── Xcode Command Line Tools ────────────────────────────────────
 if ! xcode-select -p &>/dev/null; then
     echo "==> Installing Xcode Command Line Tools..."


### PR DESCRIPTION
## 背景

\`brew bundle\` でcaskを連続インストールすると, cask毎に \`sudo\` が走るためパスワード入力が連発する. Brewfile に cask が 20+ ある現状, 1回のセットアップで 10〜15 回パスワードを打つことになり実用に堪えない.

setup.sh の \`start_sudo_keepalive\` は同一 tty 内のキャッシュしか効かず, brew cask 内部の subprocess は別 tty / detached 状態になるため keepalive をすり抜けて素のプロンプトが出る. **sudo の認証手段そのものを Touch ID に切り替えるのが本筋.**

## 修正

macOS Sonoma 以降が標準提供する \`/etc/pam.d/sudo_local\` に \`pam_tid.so\` ルールを追加する.

\`\`\`
auth       sufficient     pam_tid.so
\`\`\`

\`sudo_local\` は \`/etc/pam.d/sudo\` と違い OS update でリセットされない設計のため, 一度書けば永続する.

## 安全性

- \`sufficient\` なので Touch ID 不在/失敗時は通常のパスワード認証へ fallthrough
  - Touch ID 未登録ユーザー / Mac mini 等の Touch ID 非対応ハードでも害なし
- 既存 \`sudo_local\` の内容は保持して append のみ (Codex review で指摘・修正)
- \`grep -q '^auth.*pam_tid\\.so'\` で冪等性を担保
- \`sudo_local.template\` ファイルの存在で Sonoma+ を判定 (古い macOS では何もしない)

## 効果

セットアップ最初の sudo (start_sudo_keepalive) で 1 回パスワードを打ったあとは, 以降の sudo (brew cask など) 全てが Touch ID プロンプトに変わる. 普段使いでも \`sudo\` が指紋で通る.

## Test plan

- [ ] CI (Validate) pass (\`setup.sh\` は validate 対象外だが念のため)
- [ ] 新規 Mac で \`bash <(curl ... setup.sh)\` → brew bundle の sudo プロンプトが Touch ID に
- [ ] 既存 sudo_local がある環境で再実行 → 既存内容が保持される + pam_tid 行が append される
- [ ] 既に pam_tid 行が入っている環境で再実行 → 何もしない (冪等)

🤖 Generated with [Claude Code](https://claude.com/claude-code)