### PR TITLE
fix(gitconfig): remove ghq.root override so it defaults to ~/ghq

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -93,8 +93,5 @@
 [pretty]
     custom = "%C(magenta)%h%C(red)%d %C(yellow)%ar %C(green)%s %C(yellow)(%an)"
 
-[ghq]
-    root = ~/src
-
 [include]
     path = ~/.gitconfig.local


### PR DESCRIPTION
## 問題
chezmoi 適用後に `gcd`/`ghqcd`（fzf ヘルパー）で ghq リポジトリが一切候補に出なくなっていた。

## 原因
テンプレート `dot_gitconfig.tmpl` に `[ghq] root = ~/src` が入っていたが、`~/src` は存在せず、リポジトリ77個はすべて `~/ghq`（ghq のデフォルト root）にある。chezmoi 導入でこの override が `~/.gitconfig` に反映され、`ghq list` が0件 → ヘルパーが空になっていた。

## 対応
`[ghq]` セクションを削除。`ghq.root` 未設定時は ghq がデフォルトの `~/ghq` を使うため、実体と一致する。リポジトリの移動は不要。

## 確認
- `ghq root` → `/Users/tkt/ghq`
- `ghq list` → 77件
- `gcd` のフィルタ・移動先ディレクトリの実在を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)