### PR TITLE
Brewfile管理外パッケージをbrew bundle実行時に警告する

### DIFF
--- a/run_onchange_before_install-packages.sh.tmpl
+++ b/run_onchange_before_install-packages.sh.tmpl
@@ -41,6 +41,7 @@ fi
 echo "Running brew bundle..."
 if [ "$MAS_SIGNED_IN" = true ]; then
     brew bundle --file="$BREWFILE"
+    CLEANUP_BREWFILE="$BREWFILE"
 else
     if grep -q '^[[:space:]]*mas ' "$BREWFILE" 2>/dev/null; then
         echo "==> [SKIP] Mac App Store 未サインインのため mas パッケージはスキップします"
@@ -49,4 +50,29 @@ else
     TMPBREWFILE=$(mktemp)
     grep -v '^[[:space:]]*mas ' "$BREWFILE" > "$TMPBREWFILE"
     brew bundle --file="$TMPBREWFILE"
+    CLEANUP_BREWFILE="$TMPBREWFILE"
+fi
+
+# ── Brewfile 管理外パッケージの検知 (drift warning) ──────────────
+# Brewfile に無い formula/cask (例: 過去に手動 `brew install node` した野良
+# インストール) は brew upgrade で追従されず放置される。依存ライブラリ
+# (icu4c 等) だけが先に上がると ABI 不整合で dyld エラーになることがある
+# (例: node が `Library not loaded: .../libicui18n.74.dylib` で起動不能)。
+#
+# `brew bundle cleanup` (--force 無し) は削除を実行せず候補を表示するだけ
+# なので、ここでは検知・警告に留め、実際に消すかどうかはユーザーの判断に
+# 委ねる (無関係な手動インストールを誤って消さないため)。
+CLEANUP_PREVIEW="$(brew bundle cleanup --file="$CLEANUP_BREWFILE" 2>&1 || true)"
+if printf '%s\n' "$CLEANUP_PREVIEW" | grep -q '^Would '; then
+    cat <<EOF
+
+==> [WARN] Brewfile に無い Homebrew パッケージが見つかりました:
+$CLEANUP_PREVIEW
+
+    これらは Brewfile 管理外のため brew upgrade で追従されず、依存ライブラリ
+    とのバージョン不整合で壊れることがあります。
+    削除する場合: brew bundle cleanup --force --file="$BREWFILE"
+    残したい場合は Brewfile に追記して管理下に置いてください。
+
+EOF
 fi

--- a/run_onchange_before_install-packages.sh.tmpl
+++ b/run_onchange_before_install-packages.sh.tmpl
@@ -62,7 +62,12 @@ fi
 # `brew bundle cleanup` (--force 無し) は削除を実行せず候補を表示するだけ
 # なので、ここでは検知・警告に留め、実際に消すかどうかはユーザーの判断に
 # 委ねる (無関係な手動インストールを誤って消さないため)。
-CLEANUP_PREVIEW="$(brew bundle cleanup --file="$CLEANUP_BREWFILE" 2>&1 || true)"
+#
+# --no-mas necessary: brew bundle cleanup はデフォルトで Mac App Store (mas)
+# アプリも管理対象に含める。この Brewfile の mas エントリは Xcode 1つだけ
+# なので、--no-mas を付けないと「Brewfile に無い」他の App Store アプリまで
+# 警告・削除候補に出てしまう (Codex review PR #101 で指摘)。
+CLEANUP_PREVIEW="$(brew bundle cleanup --no-mas --file="$CLEANUP_BREWFILE" 2>&1 || true)"
 if printf '%s\n' "$CLEANUP_PREVIEW" | grep -q '^Would '; then
     cat <<EOF
 
@@ -71,7 +76,7 @@ $CLEANUP_PREVIEW
 
     これらは Brewfile 管理外のため brew upgrade で追従されず、依存ライブラリ
     とのバージョン不整合で壊れることがあります。
-    削除する場合: brew bundle cleanup --force --file="$BREWFILE"
+    削除する場合: brew bundle cleanup --force --no-mas --file="$BREWFILE"
     残したい場合は Brewfile に追記して管理下に置いてください。
 
 EOF


### PR DESCRIPTION
## Summary

- Homebrewでnodeを直接インストールした環境で `Library not loaded: .../libicui18n.74.dylib` により node が起動しなくなる事象を調査
- 原因: このdotfilesはnodeを `mise` 管理する設計で、Brewfileにはnodeが含まれていない。にもかかわらずHomebrew版nodeが野良インストールされていると、`brew upgrade` で `icu4c` だけが先に上がりABI不整合でdyld起動エラーになる
- Brewfile管理外のパッケージは`brew bundle`だけでは検知できず放置されるため、`run_onchange_before_install-packages.sh.tmpl` で `brew bundle` 実行後に `brew bundle cleanup`(`--force`なしのdry-run)を使って検知し、該当パッケージがあれば警告メッセージを表示するようにした
- 誤って無関係な手動インストールを消さないよう、実際の削除はユーザー判断に委ねる非破壊的な実装

## Test plan

- [ ] `bash -n run_onchange_before_install-packages.sh.tmpl` で構文チェック済み
- [ ] `chezmoi execute-template --init` でテンプレート内の未定義関数チェックにひっかからないことを確認済み(既存の `.chezmoi.yaml.tmpl` 側の `promptStringOnce` 未定義エラーは本PRと無関係の既存事象)
- [ ] 実機のMacで `chezmoi apply` を実行し、Brewfile管理外パッケージがある場合に警告が表示されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01CFcwPYzdBekCqyJuQfz1Ss)_